### PR TITLE
Typo Fixes

### DIFF
--- a/other/extensions.md
+++ b/other/extensions.md
@@ -1,6 +1,6 @@
 # Index of Available Extensions
 
-###List of extensions for Makeroid
+### List of extensions for Makeroid
 
 <hr>
 
@@ -19,7 +19,7 @@ _This topic will be updated regularly. If you have made a new extension, then pl
 - [Sound Analysis Extension](http://appinventor.mit.edu/extensions/)
 - [Vector Arithmetic Extension](http://appinventor.mit.edu/extensions/)
 		
-## :robot: Mad Robots
+## 🤖 Mad Robots
 
 - [Gyro Sensor Extension](https://groups.google.com/d/msg/app-inventor-open-source-dev/M7NookKPhQQ/WCN5yak3EAAJ)
 - [Sound Extension](https://groups.google.com/d/msg/app-inventor-open-source-dev/M7NookKPhQQ/WCN5yak3EAAJ)


### PR DESCRIPTION
- Added space between the "##" and the "List of extensions for Makeroid" title to apply formatting. [Typo]
- Changed Mad Robots emoji form from ":robot :" to unicode style robot. [Change] (Reason: The documentation didn't use to show it as an emoji but just as text.)

![robotproblem](https://user-images.githubusercontent.com/17576065/35196430-fae7e850-fee2-11e7-8fc4-ade89a79c571.png)
